### PR TITLE
fix(Dockerfile): include webapp/ package so the GUI can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN pip install --no-cache-dir . "streamlit>=1.32.0"
 
 # Copy application files
 COPY app.py .
+COPY webapp/ webapp/
 COPY .streamlit/ .streamlit/
 
 # Copy default config


### PR DESCRIPTION
## Summary

Add `COPY webapp/ webapp/` to the Dockerfile so the GUI starts.

## Context

The Streamlit entrypoint `app.py` (line 7) imports:

```python
from webapp.ui import main
```

But the current Dockerfile only copies `app.py`, `summarizer/`, `.streamlit/` and `summarizer.yaml`. The `webapp/` package is missing from the resulting image, so the GUI crashes at first request with:

```
ModuleNotFoundError: No module named 'webapp'
  File "/app/app.py", line 7, in <module>
    from webapp.ui import main
```

Confusingly, the `HEALTHCHECK CMD curl -f http://localhost:8501/_stcore/health` succeeds — that endpoint reports Streamlit framework state, not app code state — so the container is reported `healthy` even when the page is broken.

## Test plan

- [x] Build the image with the patch applied: `docker build -t summarize:test .`
- [x] Run it and open `http://localhost:8501/` in a browser → app renders
- [x] `docker exec <container> python3 -c "from webapp.ui import main; print(main)"` → no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
