### PR TITLE
feat: add yt-dlp downloader for IG/TikTok/X/Reddit/FB

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ core_requirements = [
     "pytubefix>=1.6.3", 
     "groq>=0.4.2",
     "openai>=1.3.7",
+    "yt-dlp>=2025.4.30",
     "aiohttp>=3.9.0",
     "requests>=2.31.0",
     "wget>=3.2",

--- a/summarizer/downloaders/manager.py
+++ b/summarizer/downloaders/manager.py
@@ -6,6 +6,7 @@ from typing import Optional
 from ..exceptions import AudioProcessingError, UnsupportedSourceError
 from .cobalt import CobaltDownloader
 from .youtube import YouTubeDownloader
+from .ytdlp import YtdlpDownloader
 
 
 class DownloadManager:
@@ -17,6 +18,7 @@ class DownloadManager:
         )
         self.downloaders = [
             YouTubeDownloader(),
+            YtdlpDownloader(),
             CobaltDownloader(self.cobalt_base_url),
         ]
 

--- a/summarizer/downloaders/ytdlp.py
+++ b/summarizer/downloaders/ytdlp.py
@@ -1,0 +1,103 @@
+"""yt-dlp downloader for non-YouTube platforms (IG, TikTok, X, Reddit, etc.)."""
+
+import os
+import tempfile
+import uuid
+from typing import Optional
+from urllib.parse import urlparse
+
+import yt_dlp
+
+from ..exceptions import AudioProcessingError, TranscriptError
+from ..handlers import process_audio_file
+from ..progress import ProgressSpinner, print_status
+from .base import BaseDownloader
+from .youtube import is_youtube_url
+
+
+# Hosts where yt-dlp's local extractors handle content that Cobalt cannot
+# reach without cookies (IG, TikTok, X, Reddit, FB). YouTube is excluded so
+# the lighter pytubefix path keeps owning it.
+YTDLP_PRIMARY_HOSTS = (
+    "instagram.com", "www.instagram.com",
+    "tiktok.com", "www.tiktok.com", "vm.tiktok.com",
+    "twitter.com", "x.com", "www.x.com",
+    "reddit.com", "www.reddit.com", "old.reddit.com",
+    "facebook.com", "www.facebook.com", "fb.watch",
+)
+
+
+class YtdlpDownloader(BaseDownloader):
+    """Downloader that uses yt-dlp locally for platforms Cobalt cannot reach."""
+
+    def supports(self, url: str) -> bool:
+        if not url or is_youtube_url(url):
+            return False
+        host = (urlparse(url).hostname or "").lower()
+        return any(host == h or host.endswith("." + h) for h in YTDLP_PRIMARY_HOSTS)
+
+    def download_audio(
+        self,
+        url: str,
+        temp_dir: Optional[str] = None,
+        verbose: bool = False,
+        audio_speed: float = 1.0,
+        use_proxy: bool = False,
+    ) -> str:
+        temp_root = temp_dir or tempfile.gettempdir()
+        temp_name = f"ytdlp_audio_{uuid.uuid4().hex}"
+        temp_template = os.path.join(temp_root, f"{temp_name}.%(ext)s")
+        processed_path = os.path.join(temp_root, f"{temp_name}_processed.mp3")
+
+        # Download raw audio; do not run FFmpegExtractAudio here — process_audio_file()
+        # converts to the target format and writing both into temp_name.mp3 would
+        # collide (ffmpeg cannot read and write the same file).
+        spinner = ProgressSpinner("Downloading audio with yt-dlp", verbose)
+        ydl_opts = {
+            "format": "bestaudio/best",
+            "outtmpl": temp_template,
+            "quiet": not verbose,
+            "no_warnings": not verbose,
+            "noplaylist": True,
+        }
+        produced_files = []
+        try:
+            spinner.start()
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                ydl.extract_info(url, download=True)
+            spinner.stop()
+
+            produced_files = [
+                os.path.join(temp_root, f) for f in os.listdir(temp_root)
+                if f.startswith(temp_name)
+            ]
+            if not produced_files:
+                raise TranscriptError("yt-dlp finished but produced no output file")
+
+            raw_path = next(
+                (p for p in produced_files if p.endswith(".mp3")),
+                produced_files[0],
+            )
+
+            spinner = ProgressSpinner("Processing audio file", verbose)
+            spinner.start()
+            process_audio_file(raw_path, processed_path, playback_speed=audio_speed)
+            spinner.stop()
+            print_status("yt-dlp audio ready", "SUCCESS", verbose)
+
+            for p in produced_files:
+                if p != processed_path and os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+            return processed_path
+        except Exception as e:
+            spinner.stop()
+            for p in produced_files + [processed_path]:
+                if os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+            raise AudioProcessingError(f"yt-dlp download failed: {str(e)}")


### PR DESCRIPTION
## Summary

Add a local yt-dlp downloader so Instagram, TikTok, X (Twitter), Reddit and Facebook URLs work without requiring a Cobalt instance with cookies.

## Why

Many social platforms — especially Instagram and TikTok — block anonymous Cobalt API queries (`error.api.fetch.empty`). The same content is often reachable via yt-dlp's per-platform extractors, which can fall back to embed pages for many public posts.

Mealie ([reference](https://github.com/mealie-recipes/mealie/blob/mealie-next/mealie/services/scraper/scraper_strategies.py)) takes the same approach for its IG recipe imports and it works in practice without cookies for public reels.

## How

New `summarizer/downloaders/ytdlp.py` with a `YtdlpDownloader(BaseDownloader)`. `manager.py` registers it between `YouTubeDownloader` and `CobaltDownloader`:

```
[YouTubeDownloader, YtdlpDownloader, CobaltDownloader]
```

- YouTube URLs keep using `pytubefix` (lighter, no change).
- IG / TikTok / X / Reddit / FB → tried first by yt-dlp.
- Anything else → falls through to Cobalt as before.

Adds `yt-dlp>=2025.4.30` to `install_requires`.

## Implementation note

yt-dlp is invoked with `format=bestaudio/best, noplaylist=True` and **without** the `FFmpegExtractAudio` postprocessor. Reason: that postprocessor would write the converted file to `<temp_name>.mp3`, which is the same path `process_audio_file()` then writes to → ffmpeg cannot read and write the same file in a single pass. Keeping the raw audio (m4a/webm/opus) and letting `process_audio_file` do the conversion avoids the round-trip and the collision.

## Test plan

- [x] IG reel from a public account → downloaded via yt-dlp, transcribed, summarized end-to-end. Provider tag in temp filename confirms it did not fall through to Cobalt.
- [x] YouTube URL → still routed through `YouTubeDownloader` (pytubefix), no regression.
- [x] Random other URL (e.g. Vimeo) → routed to Cobalt, no regression.
- [x] IG URL that yt-dlp also can't reach (login-locked) → fails through to Cobalt, then surfaces error normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
