### PR TITLE
feat: add output_language config for non-English summaries

### DIFF
--- a/summarizer/api.py
+++ b/summarizer/api.py
@@ -151,15 +151,23 @@ async def process_chunk(
 
     processed_template = template.format(text=chunk.strip())
 
+    system_content = (
+        "You are a helpful assistant specializing in video content analysis. "
+        "Always provide direct responses based on the given transcript without asking for more content."
+    )
+    output_language = config.get("output_language")
+    if output_language and str(output_language).strip().lower() not in ("auto", "none", ""):
+        system_content += (
+            f" Always write your response in {output_language}, "
+            f"regardless of the language of the transcript."
+        )
+
     data = {
         "model": config["model"],
         "messages": [
             {
                 "role": "system",
-                "content": (
-                    "You are a helpful assistant specializing in video content analysis. "
-                    "Always provide direct responses based on the given transcript without asking for more content."
-                )
+                "content": system_content,
             },
             {
                 "role": "user",


### PR DESCRIPTION
## Summary

Add an `output_language` config option so users can request summaries in a specific language without forking `prompts.json`.

## Why

By default the LLM tends to reply in English even when the transcript is in another language, because:
- The system prompt in `api.py` is in English.
- All templates in `prompts.json` are in English.

Users who want summaries in their own language currently have to either translate every prompt template by hand, or include language instructions in their prompt — both fragile because `prompts.json` ships with the package.

## How

`api.py` now reads `config.get("output_language")` and, when set, appends a single sentence to the system prompt:

```
Always write your response in <output_language>, regardless of the
language of the transcript.
```

`output_language` accepts any human-readable string the LLM understands (`"Spanish"`, `"español"`, `"German"`, `"日本語"`, etc.). Special values `"auto"`, `"none"` or empty string skip the injection. The key being absent (current default) leaves behaviour unchanged — fully backward compatible.

The kebab-case form `output-language` is also accepted from `summarizer.yaml`'s `defaults:` section thanks to the existing `key.replace("-", "_")` conversion in `config_file.py`.

## Example

`summarizer.yaml`:
```yaml
defaults:
  prompt-type: Distill Wisdom
  output-language: Spanish
```

CLI override (kebab):
```
--output-language Spanish
```

## Test plan

- [x] `output-language: Spanish` in defaults → English transcript yields Spanish summary (verified with `meta-llama/llama-4-scout-17b-16e-instruct` on Groq Cloud).
- [x] Without `output-language` set → default English behaviour, no regression.
- [x] `output-language: auto` / `output-language: ""` → injection skipped, default behaviour preserved.
- [x] Works with all prompt types (`Distill Wisdom`, `Questions and answers`, etc.) — the language instruction is added to the system prompt, so per-template structure is respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
