### PR TITLE
feat: multimodal video analysis (audio + visual + caption)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ core_requirements = [
     "pytubefix>=1.6.3", 
     "groq>=0.4.2",
     "openai>=1.3.7",
+    "yt-dlp>=2025.4.30",
     "aiohttp>=3.9.0",
     "requests>=2.31.0",
     "wget>=3.2",

--- a/summarizer/__main__.py
+++ b/summarizer/__main__.py
@@ -160,6 +160,33 @@ Examples:
         default=None,
         help="Route supported requests through Webshare proxies",
     )
+    parser.add_argument(
+        "--visual",
+        dest="enable_visual",
+        action="store_true",
+        default=None,
+        help=(
+            "Enable multimodal analysis: extract up to 5 evenly-spaced video "
+            "frames and send them with the transcript to a vision-capable model "
+            "(IG/TikTok/X/Reddit/FB only, videos <= visual-max-duration)"
+        ),
+    )
+    parser.add_argument(
+        "--no-visual",
+        dest="enable_visual",
+        action="store_false",
+        help="Force audio-only summarization even if enable-visual is set in config",
+    )
+    parser.add_argument(
+        "--visual-max-duration",
+        type=int,
+        help="Skip visual analysis for videos longer than this many seconds (default: 180)",
+    )
+    parser.add_argument(
+        "--visual-max-dimension",
+        type=int,
+        help="Resize each frame so the longest side is at most this (default: 768)",
+    )
 
     return parser.parse_args()
 
@@ -344,6 +371,9 @@ def cli():
         "output_dir": args.output_dir,
         "cobalt_base_url": args.cobalt_url,
         "use_proxy": args.use_proxy,
+        "enable_visual": args.enable_visual,
+        "visual_max_duration": args.visual_max_duration,
+        "visual_max_dimension": args.visual_max_dimension,
     }
 
     # Merge configs
@@ -417,6 +447,10 @@ def cli():
         "model": merged.get("model"),
         "verbose": verbose,
         "cache_transcript": bool(merged.get("cache_transcript", True)),
+        "enable_visual": bool(merged.get("enable_visual", False)),
+        "visual_max_duration": int(merged.get("visual_max_duration", 180)),
+        "visual_max_dimension": int(merged.get("visual_max_dimension", 768)),
+        "output_language": merged.get("output_language"),
     }
 
     if merged.get("api_key"):

--- a/summarizer/api.py
+++ b/summarizer/api.py
@@ -3,7 +3,7 @@ import re
 import asyncio
 import aiohttp
 import logging
-from typing import Dict, List, Tuple, Any
+from typing import Any, Dict, List, Optional, Tuple
 from .exceptions import APIError, ConfigurationError
 from .progress import ProgressBar, SimpleProgress, print_status
 from .proxy import get_webshare_proxy_url, should_proxy_url
@@ -122,17 +122,23 @@ async def process_chunk(
     chunk: str,
     template: str,
     config: Dict,
-    max_retries: int = 3
+    max_retries: int = 3,
+    visual_context: Optional[List[str]] = None,
 ) -> str:
     """
     Process a single chunk using the API.
-    
+
     Args:
         chunk: Text chunk to process
         template: Prompt template with {text} placeholder
         config: Configuration with API details
         max_retries: Number of retry attempts
-        
+        visual_context: Optional list of base64-encoded JPEG frames. When
+            provided, the user message becomes a multimodal content array so
+            the model sees both the transcript text and the images. Caller is
+            responsible for ensuring the frames count fits the model's image
+            limit (Llama-4-Scout on Groq: max 5).
+
     Returns:
         Generated summary text
     """
@@ -151,19 +157,40 @@ async def process_chunk(
 
     processed_template = template.format(text=chunk.strip())
 
+    system_content = (
+        "You are a helpful assistant specializing in video content analysis. "
+        "Always provide direct responses based on the given transcript without asking for more content."
+    )
+    output_language = config.get("output_language")
+    if output_language and str(output_language).strip().lower() not in ("auto", "none", ""):
+        system_content += (
+            f" Always write your response in {output_language}, "
+            f"regardless of the language of the transcript."
+        )
+
+    if visual_context:
+        # Multimodal payload: text + N image_url parts. The model receives
+        # the prompt and the visual frames in a single message so it can
+        # cross-reference what it sees with what it hears in the transcript.
+        user_content = [{"type": "text", "text": processed_template}]
+        for b64 in visual_context:
+            user_content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+            })
+    else:
+        user_content = processed_template
+
     data = {
         "model": config["model"],
         "messages": [
             {
                 "role": "system",
-                "content": (
-                    "You are a helpful assistant specializing in video content analysis. "
-                    "Always provide direct responses based on the given transcript without asking for more content."
-                )
+                "content": system_content,
             },
             {
                 "role": "user",
-                "content": processed_template
+                "content": user_content,
             }
         ],
         "max_tokens": config["max_output_tokens"]
@@ -226,16 +253,21 @@ async def process_chunk(
 async def process_chunks(
     chunks: List[Tuple[str, str]],
     template: str,
-    config: Dict
+    config: Dict,
+    visual_context: Optional[List[str]] = None,
 ) -> List[Tuple[str, str]]:
     """
     Process all chunks in parallel with rate limiting.
-    
+
     Args:
         chunks: List of (timestamp, chunk_text) tuples
         template: Prompt template
         config: Configuration dictionary
-        
+        visual_context: Optional list of base64 JPEG frames forwarded to
+            every chunk. For typical short videos there is only one chunk
+            so this is fine; for very long sources that produce multiple
+            chunks the same frames will be re-sent each time.
+
     Returns:
         List of (timestamp, summary) tuples
     """
@@ -256,7 +288,10 @@ async def process_chunks(
     ) -> Tuple[int, str, str]:
         timestamp, chunk_text = chunk_data
         async with semaphore:
-            summary = await process_chunk(chunk_text, template, config)
+            summary = await process_chunk(
+                chunk_text, template, config,
+                visual_context=visual_context,
+            )
             completed[0] += 1
             if verbose:
                 progress.update(completed[0])

--- a/summarizer/config.py
+++ b/summarizer/config.py
@@ -22,6 +22,9 @@ DEFAULT_CONFIG = {
     "max_output_tokens": 4096,
     "cobalt_base_url": os.getenv("COBALT_BASE_URL", "http://localhost:9000"),
     "cache_transcript": True,
+    "enable_visual": False,
+    "visual_max_duration": 180,
+    "visual_max_dimension": 768,
 }
 
 # API provider patterns - extensible mapping of URL patterns to env var names

--- a/summarizer/config_file.py
+++ b/summarizer/config_file.py
@@ -106,6 +106,9 @@ def merge_configs(file_config: Dict, cli_args: Dict) -> Dict:
         "output_dir": "summaries",
         "cobalt_base_url": os.getenv("COBALT_BASE_URL", "http://localhost:9000"),
         "cache_transcript": True,
+        "enable_visual": False,
+        "visual_max_duration": 180,
+        "visual_max_dimension": 768,
     }
 
     # Apply file config defaults

--- a/summarizer/core.py
+++ b/summarizer/core.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import logging
+import os
+from urllib.parse import urlparse
 
 # Re-export for backward compatibility
 from .config import DEFAULT_CONFIG as CONFIG, get_api_key, validate_config
@@ -23,6 +25,7 @@ from .transcription import (
     format_timestamp,
 )
 from .downloaders import download_youtube_audio
+from .downloaders.ytdlp import YtdlpDownloader, YTDLP_PRIMARY_HOSTS
 from .api import (
     chunk_text,
     extract_and_clean_chunks,
@@ -31,6 +34,7 @@ from .api import (
     format_summary_with_timestamps,
     parse_response_content,
 )
+from .multimodal import extract_video_frames, MAX_FRAMES_HARD_CAP
 from .prompts import load_prompt_template, get_available_prompts
 from .exceptions import (
     SummarizerError,
@@ -41,6 +45,84 @@ from .exceptions import (
     AudioProcessingError,
     SourceNotFoundError,
 )
+
+
+def _is_ytdlp_visual_eligible(url: str) -> bool:
+    """Return True if the URL host is one yt-dlp can give us a video file for."""
+    host = (urlparse(url or "").hostname or "").lower()
+    return any(
+        host == h or host.endswith("." + h) for h in YTDLP_PRIMARY_HOSTS
+    )
+
+
+def _fetch_visual_and_transcript(config: dict, verbose: bool):
+    """Download video + audio + metadata once, extract frames, transcribe audio.
+
+    Returns (transcript, visual_context, caption) where visual_context is None
+    if duration exceeds the configured cap (a warning is printed and the
+    caller falls back transparently to audio-only reasoning).
+    """
+    source_url = config.get("source_url_or_path", "")
+    max_duration = float(config.get("visual_max_duration", 180))
+    max_dimension = int(config.get("visual_max_dimension", 768))
+
+    downloader = YtdlpDownloader()
+    media = downloader.download_with_metadata(
+        source_url,
+        verbose=verbose,
+        audio_speed=float(config.get("audio_speed", 1.0)),
+    )
+
+    audio_path = media.get("audio_path")
+    video_path = media.get("video_path")
+    caption = media.get("caption")
+    duration = media.get("duration")
+
+    visual_context = None
+    try:
+        if duration and duration > max_duration:
+            print_status(
+                f"Visual analysis is not available for videos longer than "
+                f"{int(max_duration)}s (this video is {duration:.0f}s). "
+                f"Falling back to audio-only summary.",
+                "WARNING",
+                verbose,
+            )
+        elif video_path and os.path.isfile(video_path):
+            print_status(
+                f"Extracting up to {MAX_FRAMES_HARD_CAP} frames for visual context",
+                "PROCESSING",
+                verbose,
+            )
+            visual_context = extract_video_frames(
+                video_path,
+                n_frames=MAX_FRAMES_HARD_CAP,
+                max_dimension=max_dimension,
+            )
+            print_status(
+                f"Visual context ready: {len(visual_context)} frames",
+                "SUCCESS",
+                verbose,
+            )
+
+        # Transcribe the audio track yt-dlp gave us. We bypass get_transcript()
+        # here because we already have the audio file on disk and don't want
+        # to re-download.
+        transcript = transcribe_audio(
+            audio_path,
+            config.get("transcription_method", "Cloud Whisper"),
+            verbose,
+            config.get("whisper_model", "tiny"),
+            config.get("language", "auto"),
+        )
+        return transcript, visual_context, caption
+    finally:
+        for path in (audio_path, video_path):
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
 
 # Setup logging
 logging.basicConfig(
@@ -86,10 +168,34 @@ def main(config: dict) -> str:
             config["api_key"] = get_api_key(config)
         print_status("API configuration validated", "SUCCESS", verbose)
 
-        # Get transcript
-        transcript = get_transcript(config)
+        # Decide whether to take the multimodal path. It activates only when
+        # the user opted in (`enable_visual: true`) AND the URL is one yt-dlp
+        # can give us a video file for (IG/TikTok/X/Reddit/FB).
+        visual_context = None
+        caption = None
+        source_url = config.get("source_url_or_path", "") or ""
+        if (
+            config.get("enable_visual")
+            and _is_ytdlp_visual_eligible(source_url)
+        ):
+            transcript, visual_context, caption = _fetch_visual_and_transcript(
+                config, verbose
+            )
+        else:
+            transcript = get_transcript(config)
+
         if not transcript or not transcript.strip():
             raise TranscriptError("No transcript content to process")
+
+        # If the platform gave us the author's caption, prepend it so the
+        # model has the same textual context a viewer would have when they
+        # opened the post.
+        if caption:
+            transcript = (
+                f"Caption from the author of the post:\n"
+                f"\"\"\"\n{caption}\n\"\"\"\n\n"
+                f"Audio transcript:\n{transcript}"
+            )
 
         # Extract chunks with timestamps
         with ProgressSpinner("Preparing content chunks", verbose) as spinner:
@@ -125,7 +231,7 @@ def main(config: dict) -> str:
 
         try:
             summaries = loop.run_until_complete(
-                process_chunks(chunks, template, config)
+                process_chunks(chunks, template, config, visual_context=visual_context)
             )
             if not summaries:
                 raise APIError("No valid summaries generated")

--- a/summarizer/downloaders/manager.py
+++ b/summarizer/downloaders/manager.py
@@ -6,6 +6,7 @@ from typing import Optional
 from ..exceptions import AudioProcessingError, UnsupportedSourceError
 from .cobalt import CobaltDownloader
 from .youtube import YouTubeDownloader
+from .ytdlp import YtdlpDownloader
 
 
 class DownloadManager:
@@ -17,6 +18,7 @@ class DownloadManager:
         )
         self.downloaders = [
             YouTubeDownloader(),
+            YtdlpDownloader(),
             CobaltDownloader(self.cobalt_base_url),
         ]
 

--- a/summarizer/downloaders/ytdlp.py
+++ b/summarizer/downloaders/ytdlp.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 import uuid
-from typing import Optional
+from typing import Dict, Optional
 from urllib.parse import urlparse
 
 import yt_dlp
@@ -101,3 +101,91 @@ class YtdlpDownloader(BaseDownloader):
                     except OSError:
                         pass
             raise AudioProcessingError(f"yt-dlp download failed: {str(e)}")
+
+    def download_with_metadata(
+        self,
+        url: str,
+        temp_dir: Optional[str] = None,
+        verbose: bool = False,
+        audio_speed: float = 1.0,
+    ) -> Dict[str, Optional[str]]:
+        """Download both audio and the original video file plus metadata.
+
+        Returns a dict with:
+          - audio_path: processed mp3 ready for Whisper (always present)
+          - video_path: original video file kept on disk for frame extraction
+            (None if yt-dlp returned audio-only formats)
+          - caption: post description / caption text from the platform
+            (None if not provided by the extractor)
+          - title: media title (None if absent)
+          - duration: float seconds (None if absent)
+
+        Caller is responsible for deleting `video_path` once done with it.
+        """
+        temp_root = temp_dir or tempfile.gettempdir()
+        temp_name = f"ytdlp_full_{uuid.uuid4().hex}"
+        temp_template = os.path.join(temp_root, f"{temp_name}.%(ext)s")
+        processed_audio = os.path.join(temp_root, f"{temp_name}_processed.mp3")
+
+        # Ask for best video+audio so we get a real video file to extract
+        # frames from. yt-dlp will mux into a single container when possible.
+        ydl_opts = {
+            "format": "bestvideo*+bestaudio/best",
+            "outtmpl": temp_template,
+            "quiet": not verbose,
+            "no_warnings": not verbose,
+            "noplaylist": True,
+        }
+        produced_files = []
+        spinner = ProgressSpinner("Downloading video with yt-dlp", verbose)
+        try:
+            spinner.start()
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=True) or {}
+            spinner.stop()
+
+            produced_files = [
+                os.path.join(temp_root, f) for f in os.listdir(temp_root)
+                if f.startswith(temp_name)
+            ]
+            if not produced_files:
+                raise TranscriptError("yt-dlp finished but produced no file")
+
+            # Pick the largest file as the main video (mp4/mkv/webm). It also
+            # contains the audio track that we'll feed to ffmpeg for the mp3.
+            video_path = max(produced_files, key=lambda p: os.path.getsize(p))
+
+            spinner = ProgressSpinner("Extracting audio track", verbose)
+            spinner.start()
+            process_audio_file(
+                video_path, processed_audio, playback_speed=audio_speed,
+            )
+            spinner.stop()
+            print_status("yt-dlp audio + video ready", "SUCCESS", verbose)
+
+            # Clean up the smaller artefacts, keep video_path and processed_audio.
+            for p in produced_files:
+                if p != video_path and os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+
+            return {
+                "audio_path": processed_audio,
+                "video_path": video_path,
+                "caption": (info.get("description") or "").strip() or None,
+                "title": (info.get("title") or "").strip() or None,
+                "duration": info.get("duration"),
+            }
+        except Exception as e:
+            spinner.stop()
+            for p in produced_files + [processed_audio]:
+                if os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+            raise AudioProcessingError(
+                f"yt-dlp download_with_metadata failed: {str(e)}"
+            )

--- a/summarizer/downloaders/ytdlp.py
+++ b/summarizer/downloaders/ytdlp.py
@@ -1,0 +1,103 @@
+"""yt-dlp downloader for non-YouTube platforms (IG, TikTok, X, Reddit, etc.)."""
+
+import os
+import tempfile
+import uuid
+from typing import Optional
+from urllib.parse import urlparse
+
+import yt_dlp
+
+from ..exceptions import AudioProcessingError, TranscriptError
+from ..handlers import process_audio_file
+from ..progress import ProgressSpinner, print_status
+from .base import BaseDownloader
+from .youtube import is_youtube_url
+
+
+# Hosts where yt-dlp's local extractors handle content that Cobalt cannot
+# reach without cookies (IG, TikTok, X, Reddit, FB). YouTube is excluded so
+# the lighter pytubefix path keeps owning it.
+YTDLP_PRIMARY_HOSTS = (
+    "instagram.com", "www.instagram.com",
+    "tiktok.com", "www.tiktok.com", "vm.tiktok.com",
+    "twitter.com", "x.com", "www.x.com",
+    "reddit.com", "www.reddit.com", "old.reddit.com",
+    "facebook.com", "www.facebook.com", "fb.watch",
+)
+
+
+class YtdlpDownloader(BaseDownloader):
+    """Downloader that uses yt-dlp locally for platforms Cobalt cannot reach."""
+
+    def supports(self, url: str) -> bool:
+        if not url or is_youtube_url(url):
+            return False
+        host = (urlparse(url).hostname or "").lower()
+        return any(host == h or host.endswith("." + h) for h in YTDLP_PRIMARY_HOSTS)
+
+    def download_audio(
+        self,
+        url: str,
+        temp_dir: Optional[str] = None,
+        verbose: bool = False,
+        audio_speed: float = 1.0,
+        use_proxy: bool = False,
+    ) -> str:
+        temp_root = temp_dir or tempfile.gettempdir()
+        temp_name = f"ytdlp_audio_{uuid.uuid4().hex}"
+        temp_template = os.path.join(temp_root, f"{temp_name}.%(ext)s")
+        processed_path = os.path.join(temp_root, f"{temp_name}_processed.mp3")
+
+        # Download raw audio; do not run FFmpegExtractAudio here — process_audio_file()
+        # converts to the target format and writing both into temp_name.mp3 would
+        # collide (ffmpeg cannot read and write the same file).
+        spinner = ProgressSpinner("Downloading audio with yt-dlp", verbose)
+        ydl_opts = {
+            "format": "bestaudio/best",
+            "outtmpl": temp_template,
+            "quiet": not verbose,
+            "no_warnings": not verbose,
+            "noplaylist": True,
+        }
+        produced_files = []
+        try:
+            spinner.start()
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                ydl.extract_info(url, download=True)
+            spinner.stop()
+
+            produced_files = [
+                os.path.join(temp_root, f) for f in os.listdir(temp_root)
+                if f.startswith(temp_name)
+            ]
+            if not produced_files:
+                raise TranscriptError("yt-dlp finished but produced no output file")
+
+            raw_path = next(
+                (p for p in produced_files if p.endswith(".mp3")),
+                produced_files[0],
+            )
+
+            spinner = ProgressSpinner("Processing audio file", verbose)
+            spinner.start()
+            process_audio_file(raw_path, processed_path, playback_speed=audio_speed)
+            spinner.stop()
+            print_status("yt-dlp audio ready", "SUCCESS", verbose)
+
+            for p in produced_files:
+                if p != processed_path and os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+            return processed_path
+        except Exception as e:
+            spinner.stop()
+            for p in produced_files + [processed_path]:
+                if os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass
+            raise AudioProcessingError(f"yt-dlp download failed: {str(e)}")

--- a/summarizer/multimodal.py
+++ b/summarizer/multimodal.py
@@ -1,0 +1,141 @@
+"""Visual frame extraction for multimodal video summarization.
+
+Extracts a small fixed number of evenly-spaced JPEG frames from a video file
+using ffmpeg, resizes them, and returns base64-encoded data URLs ready for the
+OpenAI-compatible chat completions image_url payload.
+
+The 5-frames cap exists because Llama-4-Scout on Groq currently rejects
+requests with more than 5 images (`error: "This model supports up to 5
+images"`). Other vision-capable models may have different limits — adjust
+`MAX_FRAMES_HARD_CAP` if you change provider/model.
+"""
+
+import base64
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import List, Optional
+
+from .exceptions import AudioProcessingError
+
+
+# Groq Llama-4-Scout hard cap, May 2026. Trying to send more returns
+# "Too many images provided. This model supports up to 5 images".
+MAX_FRAMES_HARD_CAP = 5
+
+
+def ffprobe_duration(video_path: str) -> Optional[float]:
+    """Return duration of the video in seconds, or None if probing fails."""
+    if not os.path.isfile(video_path):
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                video_path,
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        return float(result.stdout.strip())
+    except (ValueError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def extract_video_frames(
+    video_path: str,
+    n_frames: int = MAX_FRAMES_HARD_CAP,
+    max_dimension: int = 768,
+    output_dir: Optional[str] = None,
+) -> List[str]:
+    """Extract `n_frames` evenly-distributed JPEG frames from `video_path`.
+
+    Frames are sampled at timestamps `duration * (i + 0.5) / n_frames` for
+    i in 0..n_frames-1 — i.e. centered within their share of the timeline,
+    which gives a more representative slice than starting at exactly t=0
+    (often a black frame or splash) and ending at the end (often a fadeout).
+
+    Args:
+        video_path: Path to a video file readable by ffmpeg.
+        n_frames: How many frames to extract. Capped at MAX_FRAMES_HARD_CAP
+            because Llama-4-Scout on Groq rejects more than that.
+        max_dimension: Maximum length of the longer side after resize. Keeps
+            tokens reasonable while preserving enough detail for the model.
+        output_dir: Where to write the frame files. If None, a tmpdir is used
+            and cleaned up at the end (frames are returned as base64 anyway).
+
+    Returns:
+        List of base64-encoded JPEG strings (no `data:` prefix). Caller adds
+        the data URL prefix when building the chat payload.
+
+    Raises:
+        AudioProcessingError: if duration probing or ffmpeg fails.
+    """
+    n_frames = min(max(n_frames, 1), MAX_FRAMES_HARD_CAP)
+
+    duration = ffprobe_duration(video_path)
+    if duration is None or duration <= 0:
+        raise AudioProcessingError(
+            f"Could not probe duration of video: {video_path}"
+        )
+
+    cleanup = output_dir is None
+    out = output_dir or tempfile.mkdtemp(prefix="summarize_frames_")
+
+    try:
+        timestamps = [duration * (i + 0.5) / n_frames for i in range(n_frames)]
+        frame_paths: List[str] = []
+
+        for idx, ts in enumerate(timestamps):
+            frame_path = os.path.join(out, f"frame_{idx:02d}.jpg")
+            # Seek then output a single frame, scaled so that the longer side
+            # is at most max_dimension while keeping aspect ratio.
+            cmd = [
+                "ffmpeg", "-y",
+                "-ss", f"{ts:.3f}",
+                "-i", video_path,
+                "-frames:v", "1",
+                "-vf",
+                f"scale='if(gt(iw,ih),min({max_dimension},iw),-2)':"
+                f"'if(gt(iw,ih),-2,min({max_dimension},ih))'",
+                "-q:v", "5",  # JPEG quality 5/31 (1=best, 31=worst). 5 is a
+                              # good compromise for vision input.
+                frame_path,
+            ]
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60,
+            )
+            if result.returncode != 0 or not os.path.isfile(frame_path):
+                raise AudioProcessingError(
+                    f"ffmpeg failed extracting frame at {ts:.2f}s: "
+                    f"{result.stderr.strip()[:300]}"
+                )
+            frame_paths.append(frame_path)
+
+        encoded = []
+        for p in frame_paths:
+            with open(p, "rb") as fh:
+                encoded.append(base64.b64encode(fh.read()).decode("ascii"))
+        return encoded
+    finally:
+        if cleanup and os.path.isdir(out):
+            shutil.rmtree(out, ignore_errors=True)
+
+
+def frames_to_image_url_parts(frames_b64: List[str]) -> List[dict]:
+    """Build the chat-completions `image_url` content parts from b64 frames.
+
+    Returns a list of dicts ready to drop into the user message `content`
+    array alongside the text part.
+    """
+    return [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+        }
+        for b64 in frames_b64
+    ]


### PR DESCRIPTION
## Summary

Add an opt-in multimodal flow that sends both the audio transcript AND visual frames from the video to a vision-capable model, plus the post caption when the platform provides one.

## Demo

Real Instagram reel (`reel/DBEu131OI7Z/`, ~30s cooking video) processed end-to-end with `meta-llama/llama-4-scout-17b-16e-instruct` on Groq:

```
**CHAMPIÑONES EN SALSA: UNA RECETA FÁCIL Y DELICIOSA**

**IDEAS**
- La receta de champiñones en salsa es ideal para aperitivos, tapas o guarniciones.
- Utilizar champiñones portobello frescos es clave para un mejor sabor.
- La combinación de vino blanco y caldo de pollo con maicena crea una salsa suave y espesa.

**QUOTES**
- "Te encantarán estos champiñones en salsa. Tienes que probarlos porque están brutales."
```

The summary references both content from the audio narration and visual steps shown on screen.

## Why 5 frames

Llama-4-Scout on Groq currently rejects requests with more than 5 images:

```
{"error":{"message":"Too many images provided. This model supports up to 5 images","type":"invalid_request_error"}}
```

The cap is declared as `MAX_FRAMES_HARD_CAP` in `multimodal.py` for easy adjustment when other vision models with different limits are added.

## Why a 180s duration cap

Longer videos would still fit the 5-frame limit, but at 1 frame per ~36s the visual signal becomes too sparse to be useful, and audio-only summaries are typically more accurate for long-form content. The cap is configurable via `visual_max_duration`. Above the cap, a clear warning is emitted and the flow falls back to audio-only:

```
[!] Visual analysis is not available for videos longer than 180s
    (this video is 200s). Falling back to audio-only summary.
```

## Architecture

- **`summarizer/multimodal.py`** (new, ~140 lines): ffmpeg-based frame extraction. Uses `ffprobe` to read duration, then a single `-ss <ts> -i <video> -frames:v 1` invocation per frame at timestamps `duration * (i + 0.5) / n_frames` (centered samples avoid splash/fadeout frames). Output is base64-encoded JPEG strings ready for the OpenAI-compatible `image_url` payload.

- **`summarizer/downloaders/ytdlp.py`**: new `download_with_metadata()` method that fetches `bestvideo*+bestaudio` instead of `bestaudio`, returns the original video file alongside the processed mp3, and pulls `description` / `title` / `duration` from the info_dict. The existing `download_audio()` method is unchanged.

- **`summarizer/api.py`**: `process_chunk()` and `process_chunks()` gain an optional `visual_context: List[str]` kwarg. When set, the user message content becomes a multipart array `[{"type":"text",...}, {"type":"image_url",...}, ...]` matching the OpenAI-compatible vision API.

- **`summarizer/core.py`**: dispatches to a new `_fetch_visual_and_transcript()` helper when `enable_visual` is true AND the URL host is in `YTDLP_PRIMARY_HOSTS`. The helper handles the full lifecycle (download, frame extraction, transcription, cleanup) and returns `(transcript, visual_context, caption)`. The caption is prepended to the transcript before chunking so the model sees the post text the same way a viewer would.

## Configuration

YAML:
```yaml
defaults:
  enable-visual: true
  visual-max-duration: 180   # seconds; above this, fallback to audio-only
  visual-max-dimension: 768  # pixels, longest side after resize
```

CLI:
```
--visual              enable visual analysis
--no-visual           force audio-only
--visual-max-duration 180
--visual-max-dimension 768
```

Default is `enable_visual: false` — fully backward compatible.

## Test plan

- [x] 5-frame extraction on a 10s synthetic video — JPEG magic bytes validated, sizes plausible (15-18 KB each at 768px max)
- [x] End-to-end on a real public Instagram reel — 17 MB video downloaded, audio transcribed via Whisper-large-v3, 5 frames sent with caption + transcript, Spanish summary produced that references both audio and visual content
- [x] Routing regression — YouTube URLs still go through pytubefix; only hosts in `YTDLP_PRIMARY_HOSTS` take the visual path
- [x] Duration cap — 200s synthetic video correctly emits the warning and produces an audio-only summary

## Dependency note

Depends on #11 (yt-dlp downloader). The diff against `main` will show both PRs' commits until #11 is merged; once merged, this branch rebases cleanly to just the multimodal changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
