### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ core_requirements = [
 
 extras_require = {
     'whisper': ['openai-whisper'],
-    'all': ['openai-whisper']
+    'litellm': ['litellm>=1.80.0,<1.87'],
+    'all': ['openai-whisper', 'litellm>=1.80.0,<1.87']
 }
 
 setup(

--- a/summarizer/api.py
+++ b/summarizer/api.py
@@ -118,37 +118,8 @@ def parse_response_content(response: Dict[str, Any], base_url: str) -> str:
     return content
 
 
-async def process_chunk(
-    chunk: str,
-    template: str,
-    config: Dict,
-    max_retries: int = 3
-) -> str:
-    """
-    Process a single chunk using the API.
-    
-    Args:
-        chunk: Text chunk to process
-        template: Prompt template with {text} placeholder
-        config: Configuration with API details
-        max_retries: Number of retry attempts
-        
-    Returns:
-        Generated summary text
-    """
-    if not chunk.strip():
-        return ""
-
-    required_keys = ["api_key", "model", "base_url", "max_output_tokens"]
-    for key in required_keys:
-        if key not in config:
-            raise ConfigurationError(f"Missing required config parameter: {key}")
-
-    headers = {
-        "Authorization": f"Bearer {config['api_key']}",
-        "Content-Type": "application/json"
-    }
-
+def _build_messages(chunk: str, template: str, config: Dict) -> List[Dict[str, str]]:
+    """Build the messages list for a chunk summarization request."""
     processed_template = template.format(text=chunk.strip())
 
     system_content = (
@@ -162,18 +133,105 @@ async def process_chunk(
             f"regardless of the language of the transcript."
         )
 
+    return [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": processed_template},
+    ]
+
+
+async def _process_chunk_litellm(
+    chunk: str,
+    template: str,
+    config: Dict,
+    max_retries: int = 3,
+) -> str:
+    """Process a single chunk via LiteLLM (supports 100+ providers)."""
+    import litellm
+    from litellm.exceptions import (
+        AuthenticationError,
+        BadRequestError,
+        NotFoundError,
+        RateLimitError,
+        Timeout,
+    )
+
+    messages = _build_messages(chunk, template, config)
+    kwargs: Dict[str, Any] = {
+        "model": config["model"],
+        "messages": messages,
+        "max_tokens": config["max_output_tokens"],
+        "drop_params": True,
+    }
+    if config.get("api_key"):
+        kwargs["api_key"] = config["api_key"]
+
+    for attempt in range(max_retries):
+        try:
+            response = await litellm.acompletion(**kwargs)
+            content = response.choices[0].message.content or ""
+            if "please provide" in content.lower() or "please share" in content.lower():
+                return ""
+            return content.strip()
+        except asyncio.CancelledError:
+            return ""
+        except (AuthenticationError, NotFoundError, BadRequestError) as e:
+            raise APIError(f"LiteLLM request failed: {e}") from e
+        except (RateLimitError, Timeout) as e:
+            if attempt < max_retries - 1:
+                logger.warning(f"LiteLLM transient error (attempt {attempt + 1}/{max_retries}): {e}")
+                await asyncio.sleep(2 ** attempt)
+            else:
+                raise APIError(f"LiteLLM request failed after {max_retries} attempts: {e}") from e
+        except Exception as e:
+            if attempt < max_retries - 1:
+                logger.warning(f"Error processing chunk (attempt {attempt + 1}/{max_retries}): {e}")
+                await asyncio.sleep(2 ** attempt)
+            else:
+                logger.error(f"Error processing chunk after {max_retries} attempts: {e}")
+                return ""
+
+    return ""
+
+
+async def process_chunk(
+    chunk: str,
+    template: str,
+    config: Dict,
+    max_retries: int = 3
+) -> str:
+    """
+    Process a single chunk using the API.
+
+    Args:
+        chunk: Text chunk to process
+        template: Prompt template with {text} placeholder
+        config: Configuration with API details
+        max_retries: Number of retry attempts
+
+    Returns:
+        Generated summary text
+    """
+    if not chunk.strip():
+        return ""
+
+    # Use LiteLLM when base_url is "litellm"
+    if config.get("base_url") == "litellm":
+        return await _process_chunk_litellm(chunk, template, config, max_retries)
+
+    required_keys = ["api_key", "model", "base_url", "max_output_tokens"]
+    for key in required_keys:
+        if key not in config:
+            raise ConfigurationError(f"Missing required config parameter: {key}")
+
+    headers = {
+        "Authorization": f"Bearer {config['api_key']}",
+        "Content-Type": "application/json"
+    }
+
+    messages = _build_messages(chunk, template, config)
     data = {
         "model": config["model"],
-        "messages": [
-            {
-                "role": "system",
-                "content": system_content,
-            },
-            {
-                "role": "user",
-                "content": processed_template
-            }
-        ],
+        "messages": messages,
         "max_tokens": config["max_output_tokens"]
     }
 
@@ -227,7 +285,7 @@ async def process_chunk(
             else:
                 logger.error(f"Error processing chunk after {max_retries} attempts: {str(e)}")
                 return ""
-    
+
     return ""
 
 

--- a/summarizer/config.py
+++ b/summarizer/config.py
@@ -67,6 +67,10 @@ def get_api_key(cfg: Dict) -> str:
     if cfg.get("api_key"):
         return cfg["api_key"]
 
+    # LiteLLM reads API keys from provider env vars automatically
+    if cfg.get("base_url") == "litellm":
+        return "litellm"
+
     base_url = cfg.get("base_url", "").lower()
 
     if not base_url:

--- a/summarizer/config_file.py
+++ b/summarizer/config_file.py
@@ -171,6 +171,16 @@ providers:
     base_url: https://api.openai.com/v1
     model: gpt-4o-mini
 
+  # LiteLLM: access 100+ providers via a single interface
+  # pip install 'summarizer[litellm]'
+  # See https://docs.litellm.ai/docs/providers for the full list
+  litellm-anthropic:
+    base_url: litellm
+    model: anthropic/claude-sonnet-4-6
+  litellm-groq:
+    base_url: litellm
+    model: groq/llama-3.3-70b-versatile
+
 # Default settings (can be overridden by CLI)
 defaults:
   prompt-type: Questions and answers

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,262 @@
+"""Tests for LiteLLM provider integration in the summarizer API."""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Stub litellm before importing
+_fake_litellm = types.ModuleType("litellm")
+_fake_exceptions = types.ModuleType("litellm.exceptions")
+
+
+class _AuthenticationError(Exception):
+    pass
+
+
+class _BadRequestError(Exception):
+    pass
+
+
+class _NotFoundError(Exception):
+    pass
+
+
+class _RateLimitError(Exception):
+    __module__ = "litellm.exceptions"
+    __qualname__ = "RateLimitError"
+
+
+class _Timeout(Exception):
+    __module__ = "litellm.exceptions"
+    __qualname__ = "Timeout"
+
+
+_fake_exceptions.AuthenticationError = _AuthenticationError
+_fake_exceptions.BadRequestError = _BadRequestError
+_fake_exceptions.NotFoundError = _NotFoundError
+_fake_exceptions.RateLimitError = _RateLimitError
+_fake_exceptions.Timeout = _Timeout
+
+_fake_litellm.exceptions = _fake_exceptions
+_fake_litellm.acompletion = AsyncMock()
+
+sys.modules["litellm"] = _fake_litellm
+sys.modules["litellm.exceptions"] = _fake_exceptions
+
+
+def _make_response(content):
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _fake_litellm.acompletion.reset_mock()
+    _fake_litellm.acompletion.side_effect = None
+    _fake_litellm.acompletion.return_value = _make_response("This is a test summary.")
+    yield
+
+
+LITELLM_CONFIG = {
+    "base_url": "litellm",
+    "model": "anthropic/claude-sonnet-4-6",
+    "api_key": "sk-test-123",
+    "max_output_tokens": 4096,
+}
+
+LITELLM_CONFIG_NO_KEY = {
+    "base_url": "litellm",
+    "model": "openai/gpt-4o-mini",
+    "max_output_tokens": 4096,
+}
+
+TEMPLATE = "Summarize the following text:\n{text}"
+
+
+class TestLiteLLMProcessChunk:
+    """Unit tests for the LiteLLM path in process_chunk."""
+
+    def test_basic_call(self):
+        from summarizer.api import process_chunk
+
+        result = asyncio.run(process_chunk("Hello world", TEMPLATE, LITELLM_CONFIG))
+        assert result == "This is a test summary."
+        _fake_litellm.acompletion.assert_called_once()
+
+    def test_drop_params_always_true(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_model_forwarded(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+    def test_provider_prefixed_model(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert "/" in call_kwargs["model"]
+
+    def test_api_key_forwarded(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test-123"
+
+    def test_api_key_omitted_when_none(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG_NO_KEY))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert "api_key" not in call_kwargs
+
+    def test_max_tokens_forwarded(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert call_kwargs["max_tokens"] == 4096
+
+    def test_messages_structure(self):
+        from summarizer.api import process_chunk
+
+        asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        messages = call_kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert "video content analysis" in messages[0]["content"]
+        assert messages[1]["role"] == "user"
+        assert "Hello" in messages[1]["content"]
+
+    def test_output_language_in_system_prompt(self):
+        from summarizer.api import process_chunk
+
+        config = {**LITELLM_CONFIG, "output_language": "Spanish"}
+        asyncio.run(process_chunk("Hello", TEMPLATE, config))
+        call_kwargs = _fake_litellm.acompletion.call_args[1]
+        assert "Spanish" in call_kwargs["messages"][0]["content"]
+
+    def test_empty_chunk_returns_empty(self):
+        from summarizer.api import process_chunk
+
+        result = asyncio.run(process_chunk("   ", TEMPLATE, LITELLM_CONFIG))
+        assert result == ""
+        _fake_litellm.acompletion.assert_not_called()
+
+
+class TestLiteLLMErrors:
+    """Tests for error handling with litellm-specific exceptions."""
+
+    def test_auth_error_raises_api_error(self):
+        from summarizer.api import process_chunk
+        from summarizer.exceptions import APIError
+
+        _fake_litellm.acompletion.side_effect = _AuthenticationError("Invalid key")
+        with pytest.raises(APIError, match="LiteLLM request failed"):
+            asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert _fake_litellm.acompletion.call_count == 1
+
+    def test_not_found_error_raises_api_error(self):
+        from summarizer.api import process_chunk
+        from summarizer.exceptions import APIError
+
+        _fake_litellm.acompletion.side_effect = _NotFoundError("Model not found")
+        with pytest.raises(APIError, match="LiteLLM request failed"):
+            asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert _fake_litellm.acompletion.call_count == 1
+
+    def test_bad_request_error_raises_api_error(self):
+        from summarizer.api import process_chunk
+        from summarizer.exceptions import APIError
+
+        _fake_litellm.acompletion.side_effect = _BadRequestError("context_length_exceeded")
+        with pytest.raises(APIError, match="LiteLLM request failed"):
+            asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert _fake_litellm.acompletion.call_count == 1
+
+    def test_rate_limit_retried(self):
+        from summarizer.api import process_chunk
+        from summarizer.exceptions import APIError
+
+        _fake_litellm.acompletion.side_effect = _RateLimitError("429")
+        with pytest.raises(APIError, match="after 3 attempts"):
+            asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert _fake_litellm.acompletion.call_count == 3
+
+    def test_timeout_retried(self):
+        from summarizer.api import process_chunk
+        from summarizer.exceptions import APIError
+
+        _fake_litellm.acompletion.side_effect = _Timeout("timed out")
+        with pytest.raises(APIError, match="after 3 attempts"):
+            asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert _fake_litellm.acompletion.call_count == 3
+
+    def test_empty_response_returns_empty(self):
+        from summarizer.api import process_chunk
+
+        _fake_litellm.acompletion.return_value = _make_response("")
+        result = asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert result == ""
+
+    def test_null_content_returns_empty(self):
+        from summarizer.api import process_chunk
+
+        resp = _make_response(None)
+        resp.choices[0].message.content = None
+        _fake_litellm.acompletion.return_value = resp
+        result = asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert result == ""
+
+    def test_please_provide_filtered(self):
+        from summarizer.api import process_chunk
+
+        _fake_litellm.acompletion.return_value = _make_response(
+            "Please provide the transcript so I can summarize it."
+        )
+        result = asyncio.run(process_chunk("Hello", TEMPLATE, LITELLM_CONFIG))
+        assert result == ""
+
+
+class TestLiteLLMConfig:
+    """Tests for config-level LiteLLM support."""
+
+    def test_get_api_key_litellm_returns_placeholder(self):
+        from summarizer.config import get_api_key
+
+        result = get_api_key({"base_url": "litellm", "model": "openai/gpt-4o"})
+        assert result == "litellm"
+
+    def test_get_api_key_litellm_with_explicit_key(self):
+        from summarizer.config import get_api_key
+
+        result = get_api_key({"base_url": "litellm", "api_key": "sk-real"})
+        assert result == "sk-real"
+
+    def test_non_litellm_base_url_uses_original_path(self):
+        from summarizer.api import process_chunk
+
+        config = {**LITELLM_CONFIG, "base_url": "https://api.openai.com/v1"}
+        # This should NOT use litellm path (would fail without aiohttp mock)
+        # We just verify litellm.acompletion is NOT called
+        try:
+            asyncio.run(process_chunk("Hello", TEMPLATE, config))
+        except Exception:
+            pass  # Expected to fail without aiohttp mock
+        _fake_litellm.acompletion.assert_not_called()


### PR DESCRIPTION

## Summary
- Adds LiteLLM as an alternative backend, giving users access to 100+ LLM providers (Anthropic, Groq, Together AI, AWS Bedrock, Azure, Mistral, etc.) by setting `base_url: litellm` in config
- Uses provider-prefixed model strings (e.g. `anthropic/claude-sonnet-4-6`, `groq/llama-3.3-70b-versatile`)


## Motivation
The summarizer currently calls OpenAI-compatible REST endpoints directly via aiohttp. This works for providers that expose `/chat/completions`, but requires users to know each provider's base URL. LiteLLM wraps 100+ providers behind a single `litellm.acompletion()` call that handles routing, auth, and response normalization automatically. Users just set `base_url: litellm` and a provider-prefixed model string.

## Changes
- `summarizer/api.py` - added `_process_chunk_litellm()` async function using `litellm.acompletion()` with `drop_params=True` and litellm-specific exception handling; extracted `_build_messages()` helper shared between both paths; `process_chunk()` routes to litellm when `base_url == "litellm"`
- `summarizer/config.py` - `get_api_key()` returns placeholder when using litellm (litellm reads keys from provider env vars automatically)
- `summarizer/config_file.py` - added litellm examples to the generated config template
- `setup.py` - added `litellm>=1.80.0,<1.87` as optional dependency (`pip install 'summarizer[litellm]'`)
- `tests/test_litellm_provider.py` - 21 unit tests

## Key design decisions
- **`base_url: litellm` as signal** - reuses the existing config field instead of adding a new flag. When `base_url` is `"litellm"`, the code routes to `litellm.acompletion()` instead of raw HTTP
- **`drop_params=True` always set** - silently drops per-provider-unsupported kwargs
- **litellm-specific exceptions** - `AuthenticationError`, `NotFoundError`, `BadRequestError` fail immediately (1 call); `RateLimitError`, `Timeout` retry 3x with exponential backoff
- **API key optional** - LiteLLM reads from provider env vars (`ANTHROPIC_API_KEY`, etc.)

## Tests

**1. Unit tests (21 passed):**
```
TestLiteLLMProcessChunk::test_basic_call PASSED
TestLiteLLMProcessChunk::test_drop_params_always_true PASSED
TestLiteLLMProcessChunk::test_model_forwarded PASSED
TestLiteLLMProcessChunk::test_provider_prefixed_model PASSED
TestLiteLLMProcessChunk::test_api_key_forwarded PASSED
TestLiteLLMProcessChunk::test_api_key_omitted_when_none PASSED
TestLiteLLMProcessChunk::test_max_tokens_forwarded PASSED
TestLiteLLMProcessChunk::test_messages_structure PASSED
TestLiteLLMProcessChunk::test_output_language_in_system_prompt PASSED
TestLiteLLMProcessChunk::test_empty_chunk_returns_empty PASSED
TestLiteLLMErrors::test_auth_error_raises_api_error PASSED
TestLiteLLMErrors::test_not_found_error_raises_api_error PASSED
TestLiteLLMErrors::test_bad_request_error_raises_api_error PASSED
TestLiteLLMErrors::test_rate_limit_retried PASSED
TestLiteLLMErrors::test_timeout_retried PASSED
TestLiteLLMErrors::test_empty_response_returns_empty PASSED
TestLiteLLMErrors::test_null_content_returns_empty PASSED
TestLiteLLMErrors::test_please_provide_filtered PASSED
TestLiteLLMConfig::test_get_api_key_litellm_returns_placeholder PASSED
TestLiteLLMConfig::test_get_api_key_litellm_with_explicit_key PASSED
TestLiteLLMConfig::test_non_litellm_base_url_uses_original_path PASSED
============================= 21 passed in 12.53s
```

**2. Regression (full test suite unaffected):**
```
============================= 31 passed in 11.17s
```

**3. Live E2E against Azure AI Foundry (Anthropic Claude Sonnet 4.6):**
```
Result: A cat rested on a mat on a pleasant, sunny day filled with birdsong.
LIVE E2E PASSED
```

## Risk / Compatibility
- Additive only, existing aiohttp path untouched
- `litellm` is an optional dependency (`pip install 'summarizer[litellm]'`)
- Only activates when `base_url == "litellm"`

## Example usage

**Config file (`summarizer.yaml`):**
```yaml
providers:
  litellm-anthropic:
    base_url: litellm
    model: anthropic/claude-sonnet-4-6
  litellm-groq:
    base_url: litellm
    model: groq/llama-3.3-70b-versatile
```

**CLI:**
```bash
# Set provider env var (LiteLLM reads it automatically)
export ANTHROPIC_API_KEY=sk-ant-...

python -m summarizer --provider litellm-anthropic --source "https://youtube.com/watch?v=..."
```

Works with any LiteLLM-supported provider:

- See https://docs.litellm.ai/docs/providers for 100+ more
